### PR TITLE
Wrap non-linux iterator into argv-specific type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,8 +155,29 @@ mod r#impl {
                 .map(|arg| -> &OsStr { Box::leak(arg.into_boxed_os_str()) })
                 .collect()
         });
-        v.iter().copied()
+        let args = v.iter().copied();
+        Iter { args }
     }
 
-    pub type Iter = iter::Copied<slice::Iter<'static, &'static OsStr>>;
+    pub struct Iter {
+        args: iter::Copied<slice::Iter<'static, &'static OsStr>>,
+    }
+
+    impl Iterator for Iter {
+        type Item = &'static OsStr;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            self.args.next()
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            self.args.size_hint()
+        }
+    }
+
+    impl ExactSizeIterator for Iter {
+        fn len(&self) -> usize {
+            self.args.len()
+        }
+    }
 }


### PR DESCRIPTION
This reverts part of #6. Making the return value of `argv::iter()` assignable to a variable of type `Copied<Iter<&OsStr>>` in downstream code (but only on non-linux) is not a wise API commitment.