### PR TITLE
Turn on deny(unsafe_op_in_unsafe_fn)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,29 @@
+use std::env;
+use std::process::Command;
+use std::str;
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let compiler = match rustc_minor_version() {
+        Some(compiler) => compiler,
+        None => return,
+    };
+
+    if compiler < 52 {
+        // #![deny(unsafe_op_in_unsafe_fn)]
+        // https://github.com/rust-lang/rust/issues/71668
+        println!("cargo:rustc-cfg=no_unsafe_op_in_unsafe_fn_lint");
+    }
+}
+
+fn rustc_minor_version() -> Option<u32> {
+    let rustc = env::var_os("RUSTC")?;
+    let output = Command::new(rustc).arg("--version").output().ok()?;
+    let version = str::from_utf8(&output.stdout).ok()?;
+    let mut pieces = version.split('.');
+    if pieces.next() != Some("rustc 1") {
+        return None;
+    }
+    pieces.next()?.parse().ok()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,8 +97,10 @@ mod r#impl {
     #[cfg_attr(target_os = "macos", link_section = "__DATA,__mod_init_func")]
     #[allow(dead_code)]
     unsafe extern "C" fn capture(argc: c_int, argv: *const *const c_char) {
-        ARGC = argc;
-        ARGV = argv;
+        unsafe {
+            ARGC = argc;
+            ARGV = argv;
+        }
     }
 
     pub(crate) fn iter() -> Iter {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,8 @@
 //! leaks memory on platforms other than Linux and macOS.
 
 #![doc(html_root_url = "https://docs.rs/argv/0.1.9")]
+#![cfg_attr(not(no_unsafe_op_in_unsafe_fn_lint), deny(unsafe_op_in_unsafe_fn))]
+#![cfg_attr(no_unsafe_op_in_unsafe_fn_lint, allow(unused_unsafe))]
 #![allow(
     clippy::cast_sign_loss,
     clippy::extra_unused_type_parameters,


### PR DESCRIPTION
This lint is allow-by-default for now in 2021 edition, but is going to become warn-by-default in 2024 edition.