### PR TITLE
Fix static_mut_ref warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,7 @@ mod r#impl {
 mod r#impl {
     use std::ffi::OsStr;
     use std::sync::Once;
-    use std::{env, iter, slice};
+    use std::{env, iter, ptr, slice};
 
     static ONCE: Once = Once::new();
     static mut ARGV: Vec<&'static OsStr> = Vec::new();
@@ -167,7 +167,7 @@ mod r#impl {
                 .collect();
             unsafe { ARGV = argv }
         });
-        let argv = unsafe { &ARGV };
+        let argv = unsafe { &*ptr::addr_of!(ARGV) };
         argv.iter().copied()
     }
 


### PR DESCRIPTION
New in nightly-2024-01-10 due to https://github.com/rust-lang/rust/pull/117556.

```console
warning: shared reference of mutable static is discouraged
   --> src/lib.rs:170:29
    |
170 |         let argv = unsafe { &ARGV };
    |                             ^^^^^ shared reference of mutable static
    |
    = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
    = note: reference of mutable static is a hard error from 2024 edition
    = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
    = note: `#[warn(static_mut_ref)]` on by default
help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
    |
170 |         let argv = unsafe { addr_of!(ARGV) };
    |                             ~~~~~~~~~~~~~~
```